### PR TITLE
allow api key input for openai wrapper

### DIFF
--- a/examples/mistral-large-2407.toml
+++ b/examples/mistral-large-2407.toml
@@ -1,0 +1,8 @@
+target = "mistral-large-2407"
+preset = "openai"
+url = "https://api.mistral.ai/v1"
+api_key = "my mistral api key"
+model_name = "mistral-large-2407"
+system-prompt = '''
+You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature. If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.
+'''

--- a/src/mindgard/wrappers.py
+++ b/src/mindgard/wrappers.py
@@ -379,7 +379,7 @@ def get_model_wrapper(
     elif preset == 'openai':
         check_expected_args(locals(), ['api_key'])
         api_key = cast(str, api_key)
-        return OpenAIWrapper(api_key=api_key, model_name=model_name, system_prompt=system_prompt)
+        return OpenAIWrapper(api_key=api_key, model_name=model_name, system_prompt=system_prompt, api_url=url)
     elif preset == 'azure-openai':
         check_expected_args(locals(), ['api_key', 'model_name', 'az_api_version', 'url'])
         api_key, model_name, az_api_version, url = cast(Tuple[str, str, str, str], (api_key, model_name, az_api_version, url))


### PR DESCRIPTION
needs tests but this is the crux of suggested change to allow api url input and open up access to openai-compatible apis.