### PR TITLE
Close web socket on test finish/error

### DIFF
--- a/mindgard/test.py
+++ b/mindgard/test.py
@@ -146,6 +146,9 @@ class TestImplementationProvider():
                 pass
                 
             time.sleep(period_seconds)
+
+    def close(self, client:WebPubSubClient):
+        client.close()
             
 class Test:
     def __init__(self, config:TestConfig, provider:TestImplementationProvider = TestImplementationProvider()):
@@ -160,3 +163,4 @@ class Test:
         p.register_handler(handler, wps_client, group_id)
         test_id = p.start_test(wps_client, group_id)
         p.poll_test(self._config, test_id)
+        p.close(wps_client)

--- a/tests/unit/test_lib_test_implementation_provider.py
+++ b/tests/unit/test_lib_test_implementation_provider.py
@@ -92,20 +92,27 @@ def test_init_test(requests_mock: requests_mock.Mocker):
 
 @mock.patch("mindgard.test.WebPubSubClientCredential", autospec=True)
 @mock.patch("mindgard.test.WebPubSubClient", autospec=True)
-def test_connect_websocket(mock_wps_client: mock.MagicMock, mock_wps_client_credential: mock.MagicMock):
+def test_create_websocket_client(mock_wps_client: mock.MagicMock, mock_wps_client_credential: mock.MagicMock):
     mock_wps_client_credential.return_value = {"something":"a"} # don't care what for now
     
     mock_client = mock.MagicMock(spec=WebPubSubClient)
     mock_wps_client.return_value = mock_client
 
     test_connection_url = "test_connection_url"
-
     provider = TestImplementationProvider()
-    client = provider.connect_websocket(test_connection_url)
+    client = provider.create_client(test_connection_url)
 
     mock_wps_client_credential.assert_called_once_with(client_access_url_provider=test_connection_url)
-    mock_client.open.assert_called_once()
+    mock_wps_client.assert_called_once_with(credential=mock_wps_client_credential.return_value)
     assert client == mock_client
+
+def test_connect_websocket():    
+    mock_client = mock.MagicMock(spec=WebPubSubClient)
+
+    provider = TestImplementationProvider()
+    provider.connect_websocket(mock_client)
+
+    mock_client.open.assert_called_once()
 
 def test_wrapper_to_handler():
     wrapper = MockModelWrapper()

--- a/tests/unit/test_lib_test_implementation_provider.py
+++ b/tests/unit/test_lib_test_implementation_provider.py
@@ -291,3 +291,8 @@ def test_poll_test_continues_on_bad_response(requests_mock: requests_mock.Mocker
 
     assert get_request.call_count == len(responses), "should have not returned until hasFinished is true"
 
+def test_close():
+    wps_client = mock.MagicMock(spec=WebPubSubClient)
+    provider = TestImplementationProvider()
+    provider.close(wps_client)
+    wps_client.close.assert_called_once()

--- a/tests/unit/test_lib_test_llm_command.py
+++ b/tests/unit/test_lib_test_llm_command.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import Mock
 
 from azure.messaging.webpubsubclient import WebPubSubClient
+import pytest
 from mindgard.test import Test, TestConfig, TestImplementationProvider
 from mindgard.wrappers.llm import TestStaticResponder
 
@@ -11,15 +12,33 @@ TestConfig.__test__ = False # type: ignore
 TestImplementationProvider.__test__ = False # type: ignore
 TestStaticResponder.__test__ = False # type: ignore
 
-def test_lib_runs_test_complete():
-    test_group_id = "my test group id"
-    test_wps_url = "my test wps url"
-    test_id = "my test id"
-    def mock_handler(payload: Any) -> Any:
-        return {
-            "response": f"hello {payload['prompt']}"
-        }
-    config = TestConfig(
+class MockProviderFixture():
+    """
+    Helper to set up a complete mock provider and access to the mock provider's methods/outputs
+    """
+    def __init__(self):
+        self.test_wps_url = "my test wps url"
+        self.test_group_id = "my test group id"
+        self.test_id = "my test id"
+        def mock_handler(payload: Any) -> Any:
+            return {
+                "response": f"hello {payload['prompt']}"
+            }
+        self.mock_handler = mock_handler
+        self.wps_client = Mock(spec=WebPubSubClient)
+        self.provider = Mock(spec=TestImplementationProvider)
+        self.provider.init_test.return_value = (self.test_wps_url, self.test_group_id)
+        self.provider.create_client.return_value = self.wps_client
+        self.provider.wrapper_to_handler.return_value = mock_handler
+        self.provider.start_test.return_value = self.test_id
+
+@pytest.fixture
+def mock_provider():
+    return MockProviderFixture()
+
+@pytest.fixture
+def config():
+    return TestConfig(
         api_base="your_api_base",
         api_access_token="your_api_access_token",
         target="your_target",
@@ -29,21 +48,30 @@ def test_lib_runs_test_complete():
         parallelism=1,
         wrapper=TestStaticResponder(system_prompt="test"),
     )
-    mock_wps_client = Mock(spec=WebPubSubClient)
-    mock_provider = Mock(spec=TestImplementationProvider)
-    mock_provider.init_test.return_value = (test_wps_url, test_group_id)
-    mock_provider.connect_websocket.return_value = mock_wps_client
-    mock_provider.wrapper_to_handler.return_value = mock_handler
-    mock_provider.start_test.return_value = test_id
 
-
-    test = Test(config, provider=mock_provider)
+def test_lib_runs_test_complete(mock_provider:MockProviderFixture, config:TestConfig):
+    test = Test(config, provider=mock_provider.provider)
     test.run()
 
-    mock_provider.init_test.assert_called_once_with(config)
-    mock_provider.connect_websocket.assert_called_once_with(test_wps_url)
-    mock_provider.register_handler.assert_called_once_with(mock_handler, mock_wps_client, test_group_id)
-    mock_provider.start_test.assert_called_once_with(mock_wps_client, test_group_id)
-    mock_provider.poll_test.assert_called_once_with(config, test_id) # assert that the default period parameter is used
-    mock_provider.close.assert_called_once_with(mock_wps_client)
+    mock_provider.provider.init_test.assert_called_once_with(config)
+    mock_provider.provider.create_client.assert_called_once_with(mock_provider.test_wps_url)
+    mock_provider.provider.connect_websocket.assert_called_once_with(mock_provider.wps_client)
+    mock_provider.provider.register_handler.assert_called_once_with(mock_provider.mock_handler, mock_provider.wps_client, mock_provider.test_group_id)
+    mock_provider.provider.start_test.assert_called_once_with(mock_provider.wps_client, mock_provider.test_group_id)
+    mock_provider.provider.poll_test.assert_called_once_with(config, mock_provider.test_id) # assert that the default period parameter is used
+    mock_provider.provider.close.assert_called_once_with(mock_provider.wps_client)
 
+
+def test_lib_closes_on_exception(mock_provider:MockProviderFixture, config:TestConfig):
+    """
+    Unrecovered failures during execution should not leave the test running.
+    Exception should be propagated to the caller unaltered (this is unhandled case).
+    """
+    exception = Exception("test exception")
+    mock_provider.provider.poll_test.side_effect = exception
+
+    with pytest.raises(Exception) as e:
+        test = Test(config, provider=mock_provider.provider)
+        test.run()
+    assert e.value == exception, "the same exception should be propagated (not a copy/wrap)"
+    assert mock_provider.provider.close.called, "the test should be closed even if an exception is raised"


### PR DESCRIPTION
To allow running multiple tests in a single process, avoid leaking connections.