### PR TITLE
ensure we have access to the model exceptions' trace in debug logging…

### DIFF
--- a/mindgard/external_model_handlers/llm_model.py
+++ b/mindgard/external_model_handlers/llm_model.py
@@ -67,6 +67,8 @@ def llm_message_handler(
                 error_code = temp_handler(mge)
                 if error_code == "CLIError":
                     raise mge
+                else: # ensure we have access to the eexception trace in debug logging before continuing
+                    logging.debug(f"error code: {error_code}", exc_info=True)
             except Exception as e:
                 raise e
             finally:


### PR DESCRIPTION
… even if app continuing

Prior to this change, exceptions that were deemed "ok" were logged with only their final message, despite debug level being set. This step should allow us to study failures via debug logs (e.g. `mindgard --log-level=debug test ,,, 2>debug.log`