### PR TITLE
add timeout to start test procedure

### DIFF
--- a/mindgard/test.py
+++ b/mindgard/test.py
@@ -213,7 +213,7 @@ class TestImplementationProvider():
             
         client.subscribe(CallbackType.GROUP_MESSAGE, callback)
 
-    def start_test(self, client:WebPubSubClient, group_id:str) -> str:
+    def start_test(self, client:WebPubSubClient, group_id:str, timeout:float = 10) -> str:
         logging.info(f"start_test: opening connection and starting test")
         started_condition = Condition()
         test_ids: list[str] = []
@@ -234,7 +234,9 @@ class TestImplementationProvider():
         
         logging.info("start_test: waiting for test_id")
         with started_condition:
-            started_condition.wait_for(lambda: len(test_ids) > 0)
+            found = started_condition.wait_for(lambda: len(test_ids) > 0, timeout=timeout)
+            if not found:
+                raise InternalError("Failure: timeout waiting for test to start")
             test_id = test_ids[0]
             logging.info(f"start_test: received test_id {test_id}")
             return test_id

--- a/tests/unit/test_lib_test_implementation_provider.py
+++ b/tests/unit/test_lib_test_implementation_provider.py
@@ -379,6 +379,13 @@ def test_start_test() -> None:
 
     assert test_id == want_test_id, "should return the correct test id"
 
+def test_start_test_timeout() -> None:
+    group_id = "my group id"
+    mock_wps_client = mock.MagicMock(spec=WebPubSubClient)
+    provider = TestImplementationProvider()
+    with pytest.raises(InternalError, match="Failure: timeout waiting for test to start"):
+        provider.start_test(mock_wps_client, group_id, 0)
+
 def test_poll_test_returns_using_api_token_auth_flow() -> None:
     mock_mindgard_api = mock.MagicMock(spec=MindgardApi)
 


### PR DESCRIPTION
this is to provide a basic protection for situations where the server does not inform the client of test starting in a timely manner.