### PR TITLE
Support custom dataset option for llm models.

### DIFF
--- a/mindgard/cli.py
+++ b/mindgard/cli.py
@@ -84,7 +84,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     shared_arguments(test_parser)
     test_parser.add_argument('--parallelism', type=int, help='The maximum number of parallel requests that can be made to the API.', required=False)
     test_parser.add_argument('--rate-limit', type=int, help='The maximum number of requests to make to model in one minute (default: 3600)', required=False)
-    test_parser.add_argument('--dataset', type=str, help='The dataset to use for image models', choices=valid_image_datasets, required=False)
+    test_parser.add_argument('--dataset', type=str, help='The dataset to be used for running the attacks on the given model.', required=False)
     test_parser.add_argument('--domain', type=str, help='The domain to inform the dataset used for LLMs.', choices=valid_llm_datasets, required=False)
     test_parser.add_argument('--mode', type=str, help='Specify the number of samples to use during attacks; contact Mindgard for access to \'thorough\' or \'exhaustive\' test', choices=['fast', 'thorough', 'exhaustive'], required=False)
 

--- a/mindgard/types.py
+++ b/mindgard/types.py
@@ -68,4 +68,5 @@ valid_llm_datasets = {
     "medical": "BadMedical",
     "injection": "SqlInjection",
     "rce": "Xss",
+    "xss": "Xss",
 }

--- a/mindgard/utils.py
+++ b/mindgard/utils.py
@@ -115,11 +115,19 @@ def parse_toml_and_args_into_final_args(
 
     if final_args["model_type"] == "llm":
         domain = final_args.get("domain", None)
+        dataset = final_args.get("dataset", None)
 
-        if domain and (domain not in valid_llm_datasets.keys()):
-            raise ValueError(f"Domain set in config file ({final_args['domain']}) was invalid! (choices: {[x for x in valid_llm_datasets]})")
-
-        final_args["dataset"] = valid_llm_datasets.get(domain, None)
+        if dataset is None:
+            if domain and (domain not in valid_llm_datasets.keys()):
+                raise ValueError(f"Domain set in config file ({final_args['domain']}) was invalid! (choices: {[x for x in valid_llm_datasets]})")
+            final_args["dataset"] = valid_llm_datasets.get(domain, None)
+        else:
+            
+            if not os.path.exists(dataset):
+                raise ValueError(f"Dataset {dataset} not found! Please provide a valid path to a dataset with new line separated prompts.")
+            with open(dataset, "r") as f:
+                lines = [line.rstrip('\n') for line in f]
+                final_args["dataset"] = ','.join(lines)
 
     if (final_args["model_type"] == 'image'):
         if (toml_args.get('labels') is None):


### PR DESCRIPTION
- dataset flag is now extended into llm models and takes takes precedence domain
- providing a dataset for llm models requires a path to a file with new line separated prompts.