### PR TITLE
Change validations and enforcing expected file format for datasets

### DIFF
--- a/mindgard/utils.py
+++ b/mindgard/utils.py
@@ -126,19 +126,13 @@ def parse_toml_and_args_into_final_args(
             
             if not os.path.exists(dataset):
                 raise ValueError(f"Dataset {dataset} not found! Please provide a valid path to a dataset with new line separated prompts.")
-            
-            if not dataset.endswith('.csv'):
-                raise ValueError("The uploaded file must be a CSV.")
-            
+                        
             with open(dataset, "r") as datasets_file:
                 try:
                     datasets = csv.reader(datasets_file)
                     lines = [', '.join(line).strip() for line in datasets if any(field.strip() for field in line)]
                 except csv.Error:
                     raise ValueError(f"{dataset} is not a valid CSV file!")
-                
-                if len(lines) > 1000 or len(lines) < 3:
-                    raise ValueError(f"Custom dataset must be valid with size (3 < n <= 1000)")
 
                 final_args["dataset"] = json.dumps(lines)
 

--- a/mindgard/utils.py
+++ b/mindgard/utils.py
@@ -130,10 +130,11 @@ def parse_toml_and_args_into_final_args(
             with open(dataset, "r") as datasets_file:
                 try:
                     datasets = csv.reader(datasets_file)
-                    lines = [', '.join(line).strip() for line in datasets if any(field.strip() for field in line)]
+                    all_rows = [line for line in datasets]
+                    lines = [line[0].strip() for line in all_rows]
                 except csv.Error:
                     raise ValueError(f"{dataset} is not a valid CSV file!")
-
+                
                 final_args["dataset"] = json.dumps(lines)
 
     if (final_args["model_type"] == 'image'):

--- a/tests/unit/test_arg_parsing.py
+++ b/tests/unit/test_arg_parsing.py
@@ -541,53 +541,6 @@ def test_passing_dataset_with_domain_should_fail_for_file_not_found_for_dataset(
         parse_toml_and_args_into_final_args(None, parsed_args)
     assert str(exc_info.value) == expected
 
-def test_passing_dataset_with_domain_should_fail_for_non_csv_files() -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_file = os.path.join(temp_dir, "temp.txt")
-        cli_command = "test --domain finance --dataset " + temp_file
-        content1 = "Hello world!"
-        with open(temp_file, "w") as f:
-            f.write(content1 + "\n")
-            
-        expected = "The uploaded file must be a CSV."
-        
-        with pytest.raises(ValueError) as exc_info:
-            parsed_args = parse_args(cast(List[str], cli_command.split()))
-            parse_toml_and_args_into_final_args(None, parsed_args)
-        assert str(exc_info.value) == expected
-
-def test_passing_dataset_with_domain_should_fail_for_dataset_size_less_than_3() -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_file = os.path.join(temp_dir, "temp.csv")
-        cli_command = "test --domain finance --dataset " + temp_file
-        content1 = "Hello world!"
-        content2 = "See ya!"
-        with open(temp_file, "w") as f:
-            f.write(content1 + "\n")
-            f.write(content2)
-            
-        expected = "Custom dataset must be valid with size (3 < n <= 1000)"
-        with pytest.raises(ValueError) as exc_info:
-            parsed_args = parse_args(cast(List[str], cli_command.split()))
-            parse_toml_and_args_into_final_args(None, parsed_args)
-        assert str(exc_info.value) == expected
-        
-def test_passing_dataset_with_domain_should_fail_for_dataset_size_greater_than_1000() -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_file = os.path.join(temp_dir, "temp.csv")
-        cli_command = "test --domain finance --dataset " + temp_file
-        content1 = "Hello world!"
-        with open(temp_file, "w") as f:
-            for _ in range(0, 1001):
-                f.write(content1 + "\n")
-            
-        expected = "Custom dataset must be valid with size (3 < n <= 1000)"
-        with pytest.raises(ValueError) as exc_info:
-            parsed_args = parse_args(cast(List[str], cli_command.split()))
-            parse_toml_and_args_into_final_args(None, parsed_args)
-        assert str(exc_info.value) == expected
-        
-
 def test_passing_dataset_with_domain_should_be_contents_of_multiline_file() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_file = os.path.join(temp_dir, "temp.csv")

--- a/tests/unit/test_arg_parsing.py
+++ b/tests/unit/test_arg_parsing.py
@@ -556,6 +556,24 @@ def test_passing_dataset_with_domain_should_be_contents_of_multiline_file() -> N
         final_args = parse_toml_and_args_into_final_args(None, parsed_args)
         assert final_args["dataset"] == f'["{content1}", "{content2}", "{content3}"]'
 
+def test_passing_dataset_for_llm_model_should_only_take_first_column_in_csv() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file = os.path.join(temp_dir, "invalid-data.exe")
+        cli_command = "test --domain finance --dataset " + temp_file
+        content1 = "Hello world"
+        content2 = "See ya"
+        content3 = "See ya!"
+
+        with open(temp_file, "w+t") as f:
+            f.write(f"{content1}  ,something ignored"+"\n")
+            f.write(f"{content2},ignored as well"+"\n")
+            f.write(content3)
+
+        parsed_args = parse_args(cast(List[str], cli_command.split()))
+        final_args = parse_toml_and_args_into_final_args(None, parsed_args)
+        
+        assert final_args["dataset"] == f'["{content1}", "{content2}", "{content3}"]'
+    
 
 @dataclass
 class ArgParsingTestCase:


### PR DESCRIPTION
[Remove validations on custom datasets](https://github.com/Mindgard/cli/commit/01d36dba54b5e41012d6cdd7d9b9acf8196a2c43) 

* No longer expects a file extension to have `.csv`, as the csv reader
  will fail if the file is not a valid csv.
* There's no limit imposed on the custom dataset anymore. Any upstream
   requirements will be communicated via the API.

[Only accepting the first column of a csv file row](https://github.com/Mindgard/cli/commit/64b4c629d47827d8a7f88e05df2885a7eb0b07bc) 

* The prompt used in a custom dataset row will be the first column of the
   csv file. This will enforce each prompt to be in a new line whilst allowing
   for a file to be formatted with encoding that supports csv files.