### PR TITLE
fix types and remove unused OrchestratorTestResponse

### DIFF
--- a/mindgard/orchestrator.py
+++ b/mindgard/orchestrator.py
@@ -49,35 +49,6 @@ class OrchestratorSetupResponse(BaseModel):
     url: str
     group_id: str
 
-
-class AttackModel(BaseModel):
-    id: str
-    submitted_at: str
-    submitted_at_unix: float
-    run_at: str
-    run_at_unix: float
-    state: Literal[0, 1, 2, -1]
-    state_message: Literal["Completed", "Queued", "Running", "Failed"]
-    runtime: float
-    model: str
-    dataset: str
-    attack: str
-    risk: int
-    stacktrace: Optional[str]
-
-
-class OrchestratorTestResponse(BaseModel):
-    id: str
-    mindgardModelName: str
-    source: type_orchestrator_source
-    createdAt: str
-    attacks: List[AttackModel]
-    isCompleted: bool
-    hasFinished: bool
-    risk: int
-    test_url: str
-
-
 class GetTestAttacksAttack(BaseModel):
     id: str
     attack_name: str

--- a/mindgard/run_functions/external_models.py
+++ b/mindgard/run_functions/external_models.py
@@ -3,7 +3,6 @@ from mindgard.wrappers.llm import LLMModelWrapper
 from ..orchestrator import (
     setup_orchestrator_webpubsub_request,
     OrchestratorSetupRequest,
-    OrchestratorTestResponse,
     get_test_by_id, GetTestAttacksResponse,
 )
 from ..types import (
@@ -14,7 +13,7 @@ from ..types import (
 )
 from ..ui_prefabs import poll_and_display_test, output_test_table
 
-from typing import Optional, List, Callable, Union
+from typing import Optional, Callable, Union
 from rich.progress import Progress
 from rich.table import Table
 

--- a/mindgard/run_functions/list_tests.py
+++ b/mindgard/run_functions/list_tests.py
@@ -8,7 +8,7 @@ from ..types import (
 from rich.progress import Progress
 
 from ..api_service import api_get
-from ..orchestrator import get_tests, OrchestratorTestResponse, GetTestListResponse
+from ..orchestrator import get_tests, GetTestListResponse
 
 from ..utils import print_to_stderr_as_json
 

--- a/mindgard/run_functions/sandbox_test.py
+++ b/mindgard/run_functions/sandbox_test.py
@@ -8,7 +8,7 @@ from ..ui_prefabs import poll_and_display_test
 
 from typing import Optional
 
-from ..orchestrator import submit_sandbox_test, OrchestratorTestResponse
+from ..orchestrator import GetTestAttacksResponse, submit_sandbox_test
 
 from rich.progress import Progress
 
@@ -21,7 +21,7 @@ def submit_sandbox_submit_factory(model_name: str) -> type_submit_func:
         access_token: str,
         ui_exception_map: type_ui_exception_map,
         ui_exception_progress: Progress,
-    ) -> OrchestratorTestResponse:
+    ) -> GetTestAttacksResponse:
         return submit_sandbox_test(access_token=access_token, target_name=model_name)
 
     return submit_sandbox_submit
@@ -29,10 +29,10 @@ def submit_sandbox_submit_factory(model_name: str) -> type_submit_func:
 
 def submit_sandbox_polling(
     access_token: str,
-    initial_test: OrchestratorTestResponse,
+    initial_test: GetTestAttacksResponse,
     ui_task_map: type_ui_task_map,
     ui_task_progress: Progress,
-) -> Optional[OrchestratorTestResponse]:
+) -> Optional[GetTestAttacksResponse]:
     return poll_and_display_test(
         access_token, ui_task_map, ui_task_progress, initial_test
     )

--- a/mindgard/ui_prefabs.py
+++ b/mindgard/ui_prefabs.py
@@ -4,7 +4,7 @@ from typing import Optional
 from .run_poll_display import type_ui_task_map
 
 # Orchestrator
-from .orchestrator import OrchestratorTestResponse, get_test_by_id, GetTestAttacksResponse
+from .orchestrator import get_test_by_id, GetTestAttacksResponse
 
 # Constants
 from .constants import DASHBOARD_URL

--- a/mindgard/utils.py
+++ b/mindgard/utils.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from mindgard.types import valid_image_datasets, valid_llm_datasets
 
 # Data models
-from mindgard.orchestrator import OrchestratorTestResponse, GetTestAttacksResponse
+from mindgard.orchestrator import GetTestAttacksResponse
 
 # B64 encode decode
 import base64

--- a/tests/unit/test_arg_parsing.py
+++ b/tests/unit/test_arg_parsing.py
@@ -11,7 +11,7 @@ import pytest
 from mindgard.utils import parse_toml_and_args_into_final_args
 from mindgard.types import valid_image_datasets, valid_llm_datasets
 from mindgard.cli import main, parse_args
-from mindgard.orchestrator import OrchestratorSetupRequest, OrchestratorTestResponse, GetTestAttacksResponse, \
+from mindgard.orchestrator import OrchestratorSetupRequest, GetTestAttacksResponse, \
     GetTestAttacksTest
 
 


### PR DESCRIPTION
 - recent changes had introduced a type issue between old and new model - it was in the type hint but not actually being used
 - fixing this meant that the model was no longer referenced