### PR TITLE
Update docs for running subset of attacks

### DIFF
--- a/mindgard/cli.py
+++ b/mindgard/cli.py
@@ -91,8 +91,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
                                                                          For LLM models this should be a csv formatted file path, with each prompt on a new line'''), required=False)
     test_parser.add_argument('--domain', type=str, help='The domain to inform the dataset used for LLMs.', choices=valid_llm_datasets, required=False)
     test_parser.add_argument('--mode', type=str, help='Specify the number of samples to use during attacks; contact Mindgard for access to \'thorough\' or \'exhaustive\' test', choices=['fast', 'thorough', 'exhaustive'], required=False)
-    test_parser.add_argument('--exclude', type=str, help='Exclude certain attacks from the test', action='append',required=False)
-    test_parser.add_argument('--include', type=str, help='Include certain attacks from the test', action='append',required=False)
+    test_parser.add_argument('--exclude', type=str, help=textwrap.dedent(f'''
+                                                                         Exclude certain attacks from the test. Exclusions can be done either by name or category.
+                                                                         The supported attacks can be found here - https://docs.mindgard.ai/user-guide/running-subset-of-attacks#list-of-attacks'''), action='append',required=False)
+    test_parser.add_argument('--include', type=str, help=textwrap.dedent(f'''
+                                                                         Include a selected set of attacks in the test. A name or category can be provided as part of the inclusion. 
+                                                                         The supported attacks can be found here - https://docs.mindgard.ai/user-guide/running-subset-of-attacks#list-of-attacks'''), action='append',required=False)
     
 
     validate_parser = subparsers.add_parser("validate", help="Validates that we can communicate with your model")


### PR DESCRIPTION
* Help docs for running subset of attacks along with links to attack and category names to be used in the `--exclude` and `--include` options.