### PR TITLE
Fix listing of tests

### DIFF
--- a/mindgard/run_functions/list_tests.py
+++ b/mindgard/run_functions/list_tests.py
@@ -54,7 +54,7 @@ def list_test_output(
         for test in test_list.items:
             table.add_row(
                 test.mindgard_model_name,
-                datetime.fromisoformat(test.created_at).strftime("%H:%M, %Y-%m-%d"),
+                datetime.fromisoformat(test.created_at.replace('Z', '+00:00')).strftime("%H:%M, %Y-%m-%d"),
                 f"{test.flagged_events} / {test.total_events}",
                 f"{DASHBOARD_URL}/r/test/{test.id}",
             )


### PR DESCRIPTION
* The dataformat of the tests are UTC and has the timezone information.
* Python datatime however is unable to parse these dates and thus, the `Z` in the datestring needed to be replaced.