### PR TITLE
Support overriding no of times a prompt is repeated

### DIFF
--- a/mindgard/cli.py
+++ b/mindgard/cli.py
@@ -98,6 +98,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     test_parser.add_argument('--include', type=str, help=textwrap.dedent(f'''
                                                                          Include a selected set of attacks in the test. A name or category can be provided as part of the inclusion. 
                                                                          The supported attacks can be found here - https://docs.mindgard.ai/user-guide/running-subset-of-attacks#list-of-attacks'''), action='append',required=False)
+    test_parser.add_argument('--prompt-repeats', type=int, help='The number of times to repeat the prompt for each sample in the dataset.', required=False)
     
 
     validate_parser = subparsers.add_parser("validate", help="Validates that we can communicate with your model")
@@ -169,6 +170,7 @@ def run_cli() -> None:
                             attackPack=final_args["attack_pack"],
                             exclude=final_args["exclude"],
                             include=final_args["include"],
+                            prompt_repeats=final_args["prompt_repeats"],
                         )
                         submit = model_test_submit_factory(
                             request=request,

--- a/mindgard/orchestrator.py
+++ b/mindgard/orchestrator.py
@@ -38,6 +38,7 @@ class OrchestratorSetupRequest(BaseModel):
     labels: Optional[List[str]] = None
     exclude: Optional[List[str]] = None
     include: Optional[List[str]] = None
+    prompt_repeats: Optional[int] = None
 
     @model_validator(mode="after")  # type: ignore
     def check_parallelism(self):

--- a/tests/unit/test_arg_parsing.py
+++ b/tests/unit/test_arg_parsing.py
@@ -290,11 +290,11 @@ cases = [
 @mock.patch("mindgard.cli.model_test_submit_factory")
 @mock.patch("mindgard.cli.preflight_llm", return_value=True)
 def test_orchestrator_setup_request(
-    mock_preflight_llm: mock.MagicMock,
-    mock_model_test_submit_factory:mock.MagicMock, 
-    mock_cli_run: mock.MagicMock, 
-    mock_exit: mock.MagicMock,
-    test_case: Case
+        mock_preflight_llm: mock.MagicMock,
+        mock_model_test_submit_factory: mock.MagicMock,
+        mock_cli_run: mock.MagicMock,
+        mock_exit: mock.MagicMock,
+        test_case: Case
 ):
     """
     Given a set of input arguments and a final response, validate that:
@@ -303,28 +303,29 @@ def test_orchestrator_setup_request(
     """
     with mock.patch.object(sys, 'argv', test_case.input_args):
         mock_cli_run.return_value = test_case.cli_run_response
-        
+
         main()
-        
+
         mock_model_test_submit_factory.assert_called_once_with(
             request=test_case.expected_request,
             model_wrapper=mock.ANY,
             message_handler=mock.ANY,
         )
-        
+
         received_model_wrapper = mock_model_test_submit_factory.call_args[1]['model_wrapper']
         # break this out if adding image models
         assert isinstance(
-            received_model_wrapper, 
+            received_model_wrapper,
             LLMModelWrapper
         ), "model_test_submit_factory should be called with LLMModelWrapper"
 
         for key, value in test_case.expected_wrapper_properties.items():
-            assert getattr(received_model_wrapper, key) == value, f"received_model_wrapper should have attribute '{key}' with value '{value}'"
+            assert getattr(received_model_wrapper,
+                           key) == value, f"received_model_wrapper should have attribute '{key}' with value '{value}'"
 
-        mock_cli_run.assert_called_once_with(mock_model_test_submit_factory.return_value, mock.ANY, output_func=mock.ANY, json_out=mock.ANY)
+        mock_cli_run.assert_called_once_with(mock_model_test_submit_factory.return_value, mock.ANY,
+                                             output_func=mock.ANY, json_out=mock.ANY)
         mock_exit.assert_called_once_with(test_case.expected_exit_code)
-
 
 
 argparse_success_test_cases: List[Tuple[str, Namespace]] = [
@@ -337,11 +338,13 @@ argparse_success_test_cases: List[Tuple[str, Namespace]] = [
     # when no --instance parameter is passed it should default to sandbox
     ("login --instance", Namespace(command='login', log_level='warn', instance=None)),  # missing instance value
     # new cli structure:
-    ("sandbox cfp_faces", Namespace(command='sandbox', target='cfp_faces', json=False, risk_threshold=80, log_level='warn')),
+    ("sandbox cfp_faces",
+     Namespace(command='sandbox', target='cfp_faces', json=False, risk_threshold=80, log_level='warn')),
 
     ("list tests", Namespace(command='list', list_command='tests', json=False, id=None, log_level='warn')),
     ("list tests --json", Namespace(command='list', list_command='tests', json=True, id=None, log_level='warn')),
-    ("list tests --json --id 123", Namespace(command='list', list_command='tests', json=True, id='123', log_level='warn')),
+    ("list tests --json --id 123",
+     Namespace(command='list', list_command='tests', json=True, id='123', log_level='warn')),
 ]
 
 argparse_failure_test_cases: List[str] = [
@@ -361,19 +364,26 @@ def test_argparse_expected_namespaces(test_case: Tuple[str, Namespace]) -> None:
     print(f"command: {command.split()}, namespace: {namespace}")
     parsed_args = parse_args(command.split())
     assert parsed_args == namespace
-    
+
+
 @pytest.mark.parametrize("test_case", argparse_failure_test_cases, ids=lambda x: x)
 def test_argparse_expected_failures(test_case: str) -> None:
     with pytest.raises(SystemExit):
         parse_args(test_case.split())
 
+
 def test_toml_and_args_parsing_model_type_llm():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     model_type = "llm"
     target= "my_model"
@@ -383,21 +393,26 @@ def test_toml_and_args_parsing_model_type_llm():
     with patch.dict(os.environ, {"MODEL_API_KEY": "my-api-key"}):
         with patch('builtins.open', mock_open(read_data=toml_content)):
             final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
-            
+
             assert final_args["api_key"] == "my-api-key"
             assert final_args["model_type"] == "llm"
             assert final_args["command"] == namespace.command
             assert final_args["config_file"] == namespace.config_file
             assert final_args["mode"] == "fast"
-    
-        
+
+
 def test_toml_and_args_parsing_model_type_empty():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     target= "my_model"
     system-prompt = "You are a helpful, respectful and honest assistant."
@@ -406,22 +421,28 @@ def test_toml_and_args_parsing_model_type_empty():
     with patch.dict(os.environ, {"MODEL_API_KEY": "my-api-key"}):
         with patch('builtins.open', mock_open(read_data=toml_content)):
             final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
-            
+
             assert final_args["api_key"] == "my-api-key"
             assert final_args["model_type"] == "llm"
             assert final_args["command"] == namespace.command
             assert final_args["config_file"] == namespace.config_file
-            
+
             if "MODEL_API_KEY" in os.environ:
                 del os.environ["MODEL_API_KEY"]
-            
+
+
 def test_toml_and_args_parsing_model_type_image():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -434,24 +455,30 @@ def test_toml_and_args_parsing_model_type_image():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
-        
+
         assert final_args["api_key"] == "my-api-key"
         assert final_args["model_type"] == "image"
         assert final_args["command"] == namespace.command
         assert final_args["config_file"] == namespace.config_file
-        assert final_args["risk_threshold"] == 50 # default value
-        assert final_args["parallelism"] == 5 # default value
+        assert final_args["risk_threshold"] == 50  # default value
+        assert final_args["parallelism"] == 5  # default value
+
 
 def test_toml_and_args_parsing_model_type_image_without_labels_set():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -459,20 +486,26 @@ def test_toml_and_args_parsing_model_type_image_without_labels_set():
     dataset="beans"
     system-prompt = "You are a helpful, respectful and honest assistant."
     """
-    
+
     with pytest.raises(ValueError):
         with patch('builtins.open', mock_open(read_data=toml_content)):
             final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
             assert final_args["api_key"] == "my-api-key"
             assert final_args["model_type"] == "image"
 
+
 def test_toml_and_args_parsing_model_type_image_with_labels_set():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -485,20 +518,26 @@ def test_toml_and_args_parsing_model_type_image_with_labels_set():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
         assert final_args["api_key"] == "my-api-key"
         assert final_args["model_type"] == "image"
         assert len(final_args["labels"]) == 3
 
+
 def test_toml_and_args_parsing_not_setting_risk_threshold():
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -511,19 +550,25 @@ def test_toml_and_args_parsing_not_setting_risk_threshold():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
-        
-        assert final_args["risk_threshold"] == 50 # default value
+
+        assert final_args["risk_threshold"] == 50  # default value
+
 
 def test_toml_and_args_parsing_setting_risk_threshold():
     cli_command = "test --config-file=config.toml --risk-threshold=80"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -536,19 +581,24 @@ def test_toml_and_args_parsing_setting_risk_threshold():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
-        
+
         assert final_args["risk_threshold"] == 80
-        
+
+
 def test_toml_and_args_parsing_setting_risk_threshold_zero():
     cli_command = "test --config-file=config.toml --risk-threshold=0"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=0, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=0,
+                          mode=None, exclude=None, include=None, force_multi_turn=None, prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -561,19 +611,25 @@ def test_toml_and_args_parsing_setting_risk_threshold_zero():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
         print(f'final args: {final_args}')
         assert final_args["risk_threshold"] == 0
-        
+
+
 def test_toml_and_args_parsing_setting_json():
     cli_command = "test --config-file=config.toml --risk-threshold=80 --json"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=True, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=True, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
-    
-    assert parsed_args == namespace 
-    
+
+    assert parsed_args == namespace
+
     toml_content = """
     api_key = "my-api-key"
     target= "my_model"
@@ -586,7 +642,7 @@ def test_toml_and_args_parsing_setting_json():
         "2": "healthy"
     }'''
     """
-    
+
     with patch('builtins.open', mock_open(read_data=toml_content)):
         final_args = parse_toml_and_args_into_final_args("config.toml", parsed_args)
         
@@ -594,7 +650,12 @@ def test_toml_and_args_parsing_setting_json():
     
 def test_toml_and_args_parsing_not_setting_json():
     cli_command = "test --config-file=config.toml --risk-threshold=80"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
     
     assert parsed_args == namespace 
@@ -617,9 +678,15 @@ def test_toml_and_args_parsing_not_setting_json():
         
         assert final_args["json"] == False
 
+
 def test_pass_random_dataset_not_in_approved_choices() -> None:
     cli_command = "test --config-file=config.toml --risk-threshold=80"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=80, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
     
     assert parsed_args == namespace
@@ -646,7 +713,12 @@ def test_pass_random_dataset_not_in_approved_choices() -> None:
 
 def test_passing_mode_thorough_through_toml_args() -> None:
     cli_command = "test --config-file=config.toml"
-    namespace = Namespace(command='test',config_file='config.toml', log_level='warn', json=False, az_api_version=None, prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None, tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None, api_key=None, url=None, preset=None, headers=None, header=None, target=None, risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None)
+    namespace = Namespace(command='test', config_file='config.toml', log_level='warn', json=False, az_api_version=None,
+                          prompt=None, system_prompt=None, selector=None, request_template=None, rate_limit=None,
+                          tokenizer=None, model_type=None, parallelism=None, dataset=None, domain=None, model_name=None,
+                          api_key=None, url=None, preset=None, headers=None, header=None, target=None,
+                          risk_threshold=None, mode=None, exclude=None, include=None, force_multi_turn=None,
+                          prompt_repeats=None)
     parsed_args = parse_args(cast(List[str], cli_command.split()))
     
     assert parsed_args == namespace 
@@ -744,6 +816,11 @@ def test_passing_multiple_includes_in_final_args() -> None:
     final_args = parse_toml_and_args_into_final_args(None, parsed_args)
     assert final_args["include"] == ["AntiGPT", "DevModeV2"]
 
+def test_passing_prompt_repeats_in_final_args() -> None:
+    cli_command = "test --prompt-repeats 2"
+    parsed_args = parse_args(cast(List[str], cli_command.split()))
+    final_args = parse_toml_and_args_into_final_args(None, parsed_args)
+    assert final_args["prompt_repeats"] == 2
 
 
 


### PR DESCRIPTION
* This is useful to make attacks more effective by repeating the same prompts against a target
* Usage and default details can be found here - https://docs.mindgard.ai/user-guide/testing-via-cli