### PR TITLE
Move interaction timing closer to where it takes place

### DIFF
--- a/mindgard/external_model_handlers/llm_model.py
+++ b/mindgard/external_model_handlers/llm_model.py
@@ -17,7 +17,7 @@ import logging
 from azure.messaging.webpubsubclient.models import OnGroupDataMessageArgs
 from azure.messaging.webpubsubclient import WebPubSubClient
 
-from mindgard.wrappers.llm import LLMModelWrapper, ContextManager
+from mindgard.wrappers.llm import LLMModelWrapper, ContextManager, PromptResponse
 
 # Exceptions
 from mindgard.exceptions import (
@@ -61,13 +61,12 @@ def llm_message_handler(
 
             try:
                 # would pose being explicit with __call__ so we can ctrl+f easier, not a very clear shorthand
-                start_time = time.time()
-                response = model_wrapper.__call__(
+                prompt_response = model_wrapper.__call__(
                     content=content,
                     with_context=context,
                 )
-                end_time = time.time()
-                duration_ms = (end_time - start_time) * 1000  # convert to milliseconds
+                response = prompt_response.response
+                duration_ms = prompt_response.duration_ms
             except MGException as mge:
                 error_code = temp_handler(mge)
                 if error_code == "CLIError":

--- a/mindgard/test.py
+++ b/mindgard/test.py
@@ -194,11 +194,7 @@ class TestImplementationProvider():
             if msg.data["messageType"] != "Request":
                 return
 
-            start_time = time.time()
             payload = handler(payload=msg.data["payload"])
-            end_time = time.time()
-            duration_ms = (end_time - start_time) * 1000  # convert to milliseconds
-            payload["duration_ms"] = duration_ms
             client.send_to_group(
                 "orchestrator",
                 {

--- a/tests/unit/test_test_llm_command.py
+++ b/tests/unit/test_test_llm_command.py
@@ -15,7 +15,7 @@ from azure.messaging.webpubsubclient.models import OnGroupDataMessageArgs, WebPu
 from mindgard.external_model_handlers.llm_model import llm_message_handler
 from mindgard.orchestrator import OrchestratorSetupRequest
 from mindgard.run_functions.external_models import model_test_output_factory, model_test_polling, model_test_submit_factory
-from mindgard.wrappers.llm import Context, LLMModelWrapper
+from mindgard.wrappers.llm import Context, LLMModelWrapper, PromptResponse
 from mindgard import auth
 import pytest
 from pytest_snapshot.plugin import Snapshot
@@ -47,8 +47,9 @@ class MockModelWrapper(LLMModelWrapper):
         time.sleep(0.1)
         return "hello " + input
     
-    def __call__(self, content:str, with_context:Optional[Context] = None) -> str:
-        return self.mirror(content) # mirror the input for later assertions
+    def __call__(self, content:str, with_context:Optional[Context] = None) -> PromptResponse:
+        response_content = self.mirror(content) # mirror the input for later assertions
+        return PromptResponse(prompt=content, response=response_content, duration_ms=1)
 
 @dataclass
 class _TestContext():

--- a/tests/unit/test_wrappers.py
+++ b/tests/unit/test_wrappers.py
@@ -197,7 +197,7 @@ def test_api_model_wrapper_does_not_support_multi_turn_by_default_due_to_interle
             json="eh up",
         )
         context = Context()
-        context.add(PromptResponse(prompt="Foo", response="Bar"))
+        context.add(PromptResponse(prompt="Foo", response="Bar", duration_ms=1))
         with pytest.raises(mindgard.exceptions.NotImplemented):
             wrapper("hello", context)
 
@@ -217,7 +217,7 @@ def test_api_model_wrapper_can_support_multi_turn_in_stateful_api_scenarios() ->
             json="eh up",
         )
         context = Context()
-        context.add(PromptResponse(prompt="Foo", response="Bar"))
+        context.add(PromptResponse(prompt="Foo", response="Bar", duration_ms=1))
 
         assert '"eh up"' == wrapper("hello", context)
 


### PR DESCRIPTION
* Given that interactions with the system under test can be controlled by throttling, having it in the wrapper wasn't representative of the actual timing. Therefore the timing information is moved into the closest place where the interaction takes place.
* The `PromptResponse` is enriched with timing information to used in all wrappers to return from their respective functions.