### PR TITLE
update urls to follow new domain model

### DIFF
--- a/mindgard/ui_prefabs.py
+++ b/mindgard/ui_prefabs.py
@@ -2,6 +2,8 @@
 import json
 import logging
 from typing import Optional
+
+from .dataset_generation import console
 from .run_poll_display import type_ui_task_map
 
 # Orchestrator
@@ -57,7 +59,8 @@ def output_test_table(
         print(json.dumps(test.raw, indent=4))
         return None
     else:
-        table = Table(title=f"Results - {DASHBOARD_URL}/r/test/{test.test.id}", width=80)
+        console.print(f"{DASHBOARD_URL}/results/targets/{test.test.model_name}/tests/{test.test.id}\n")
+        table = Table(title="Results", width=80)
         table.add_column("Pass", style="cyan")
         table.add_column("Name", style="magenta")
         table.add_column("Flagged Events", justify="right", style="green")

--- a/tests/unit/snapshots/test_sandbox_test_command/test_json_output/stdout.json
+++ b/tests/unit/snapshots/test_sandbox_test_command/test_json_output/stdout.json
@@ -3,7 +3,7 @@
     "test": {
         "id": "a-test-id-for-this-test",
         "has_finished": true,
-        "model_name": "<model_name>",
+        "model_name": "my-test-target",
         "total_events": 0,
         "flagged_events": 0
     },

--- a/tests/unit/snapshots/test_sandbox_test_command/test_text_output/stdout.txt
+++ b/tests/unit/snapshots/test_sandbox_test_command/test_text_output/stdout.txt
@@ -2,7 +2,10 @@ Submitting...  Submitted!
                                                                                 
 Attack blah done success                                                        
                                                                                 
-                                                                                      Results - https://sandbox.mindgard.ai/r/test/a-test-id-for-this-test      
+                                                                                https://sandbox.mindgard.ai/results/targets/my-test-target/tests/a-test-id-for-t
+his-test
+
+                                    Results                                     
 ┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Pass            ┃ Name            ┃                           Flagged Events ┃
 ┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩

--- a/tests/unit/snapshots/test_test_llm_command/test_json_output/stdout.json
+++ b/tests/unit/snapshots/test_test_llm_command/test_json_output/stdout.json
@@ -3,7 +3,7 @@
     "test": {
         "id": "my-test-id",
         "has_finished": true,
-        "model_name": "<model_name>",
+        "model_name": "my-target-model-name",
         "total_events": 10,
         "flagged_events": 5
     },

--- a/tests/unit/snapshots/test_test_llm_command/test_text_output/stdout.txt
+++ b/tests/unit/snapshots/test_test_llm_command/test_text_output/stdout.txt
@@ -2,7 +2,10 @@ Submitting...  Submitted!
                                                                                 
 Attack myattack done success                                                    
                                                                                 
-                                                                                            Results - https://sandbox.mindgard.ai/r/test/my-test-id             
+                                                                                https://sandbox.mindgard.ai/results/targets/my-target-model-name/tests/my-test-i
+d
+
+                                    Results                                     
 ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Pass          ┃ Name                   ┃                      Flagged Events ┃
 ┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩

--- a/tests/unit/test_orchestrator_polling.py
+++ b/tests/unit/test_orchestrator_polling.py
@@ -35,7 +35,7 @@ def get_valid_test_data(
 ) -> Dict[str, Any]:
     return {
         "id": id,
-        "mindgardModelName": "<model_name>",
+        "mindgardModelName": "my-target-model-name",
         "source": "user",
         "createdAt": json.dumps(datetime.now(), default=str),
         "isCompleted": True,
@@ -49,7 +49,7 @@ def build_tests_attacks_response(test_id):
         "test": {
             "id": test_id,
             "has_finished": True,
-            "model_name": "<model_name>",
+            "model_name": "my-target-model-name",
             "total_events": 10,
             "flagged_events": 3
         },

--- a/tests/unit/test_sandbox_test_command.py
+++ b/tests/unit/test_sandbox_test_command.py
@@ -13,12 +13,12 @@ import requests_mock # type: ignore
 
 
 def build_tests_attacks_response(test_id: str = "blah", attack_id: str = "blah", flagged_events: int = 0,
-                                 total_events: int = 0):
+                                 total_events: int = 0, model_name: str = "my-test-target"):
     return {
         "test": {
             "id": test_id,
             "has_finished": True,
-            "model_name": "<model_name>",
+            "model_name": model_name,
             "total_events": total_events,
             "flagged_events": flagged_events,
         },
@@ -71,6 +71,7 @@ def test_text_output(capsys: pytest.CaptureFixture[str], snapshot:Snapshot, requ
     auth.load_access_token = MagicMock(return_value="atoken")
 
     test_id: str = "a-test-id-for-this-test"
+    target_name = "my-test-target"
 
     requests_mock.post(
         f"{API_BASE}/assessments",
@@ -82,7 +83,7 @@ def test_text_output(capsys: pytest.CaptureFixture[str], snapshot:Snapshot, requ
 
     requests_mock.get(
         f"{API_BASE}/tests/{test_id}/attacks",
-        json=build_tests_attacks_response(test_id=test_id),
+        json=build_tests_attacks_response(test_id=test_id, model_name=target_name),
         status_code=200,
     )
 
@@ -98,7 +99,7 @@ def test_text_output(capsys: pytest.CaptureFixture[str], snapshot:Snapshot, requ
 
     if platform.system() == "Windows":
         # TODO: this is a basic check as Rich renders differently on windows
-        assert f"Results - https://sandbox.mindgard.ai/r/test/{test_id}" in stdout
+        assert f"https://sandbox.mindgard.ai/results/targets/{target_name}/tests/{test_id}" in stdout
         assert "Attack blah done success" in stdout
     else:
         snapshot.assert_match(stdout, 'stdout.txt')

--- a/tests/unit/test_sandbox_test_command.py
+++ b/tests/unit/test_sandbox_test_command.py
@@ -99,7 +99,7 @@ def test_text_output(capsys: pytest.CaptureFixture[str], snapshot:Snapshot, requ
 
     if platform.system() == "Windows":
         # TODO: this is a basic check as Rich renders differently on windows
-        assert f"https://sandbox.mindgard.ai/results/targets/{target_name}/tests/{test_id}" in stdout
+        assert f"https://sandbox.mindgard.ai/results/targets/{target_name}/tests/{test_id}".replace("\n","") in stdout.replace("\n","")
         assert "Attack blah done success" in stdout
     else:
         snapshot.assert_match(stdout, 'stdout.txt')

--- a/tests/unit/test_test_llm_command.py
+++ b/tests/unit/test_test_llm_command.py
@@ -61,6 +61,7 @@ class _TestContext():
     cli_completed: bool = False
 
 fixture_test_id = "my-test-id"
+fixture_target_name = "my-target-name"
 fixture_group_id = "my-group-id"
 fixture_cli_init_response = {
     "url": "dsfdfsdf",
@@ -72,7 +73,7 @@ def build_tests_attacks_response(test_id: str = fixture_test_id) -> dict:
         "test": {
             "id": test_id,
             "has_finished": False,
-            "model_name": "<model_name>",
+            "model_name": "my-target-model-name",
             "total_events": 10,
             "flagged_events": 5,
         },
@@ -98,7 +99,7 @@ def _run_llm_test(json_out:bool = True) -> None:
     model_wrapper = MockModelWrapper()
 
     request = OrchestratorSetupRequest(
-        target="mymodel",
+        target=fixture_target_name,
         parallelism=4,
         system_prompt="my system prompt",
         dataset=None,
@@ -305,7 +306,7 @@ def test_text_output(
         stdout = captured.out
         if platform.system() == "Windows":
             # TODO: this is a basic check as Rich renders differently on windows
-            assert f"Results - https://sandbox.mindgard.ai/r/test/{fixture_test_id}" in stdout
+            assert f"https://sandbox.mindgard.ai/results/targets/{fixture_target_name}/tests/{fixture_test_id}"
             assert "Attack myattack done success" in stdout
         else:
             snapshot.assert_match(stdout, 'stdout.txt')    


### PR DESCRIPTION
- tests results URL is pointing to an old URL as tests are now hung of the target model name
- update code & tests to point to new URL
- move the URL out of the table title as the URL is quite a bit wider now and makes the table comically wide and cannot be ctrl+click'd into the browser